### PR TITLE
kubecf-related deployment bumps

### DIFF
--- a/kubernetes/kubecf/Taskfile.yml
+++ b/kubernetes/kubecf/Taskfile.yml
@@ -108,6 +108,7 @@ tasks:
         kubectl -n eirini get pods
       - | # misc. helpful for debugging
         kubectl -n kubecf logs -f api-0
+        kubectl -n kubecf logs -f --tail 250 api-0 --all-containers --max-log-requests=60
         kubectl -n kubecf logs -f --tail 250 api-0 -c cloud-controller-ng-cloud-controller-ng
         kubectl -n kubecf logs -f --tail 250 api-0 -c route-registrar-route-registrar
         kubectl -n ingress-nginx logs -f --tail 250 -lapp.kubernetes.io/name=ingress-nginx

--- a/kubernetes/kubecf/Taskfile.yml
+++ b/kubernetes/kubecf/Taskfile.yml
@@ -107,11 +107,12 @@ tasks:
       - | # after cf push'ing apps, see them pop up in the kubecf-eirini namespace as pods
         kubectl -n eirini get pods
       - | # misc. helpful for debugging
-        kubectl -n kubecf logs -f api-0
+        kubectl -n ingress-nginx logs -f --tail 250 -lapp.kubernetes.io/name=ingress-nginx
+        kubectl -n kubecf logs -f --tail 250 -lname=bits
         kubectl -n kubecf logs -f --tail 250 api-0 --all-containers --max-log-requests=60
         kubectl -n kubecf logs -f --tail 250 api-0 -c cloud-controller-ng-cloud-controller-ng
         kubectl -n kubecf logs -f --tail 250 api-0 -c route-registrar-route-registrar
-        kubectl -n ingress-nginx logs -f --tail 250 -lapp.kubernetes.io/name=ingress-nginx
+        kubectl -n kubecf logs -f api-0
 
   post-install-minibroker:
     cmds:

--- a/kubernetes/kubecf/config/ingress-nginx/values.yml
+++ b/kubernetes/kubecf/config/ingress-nginx/values.yml
@@ -8,6 +8,8 @@ controller:
   config:
     proxy-body-size: 64m
     proxy-buffer-size: 16k
+  metrics:
+    enabled: false
 
 defaultBackend:
   enabled: false

--- a/kubernetes/kubecf/config/ingress-nginx/values.yml
+++ b/kubernetes/kubecf/config/ingress-nginx/values.yml
@@ -8,8 +8,6 @@ controller:
   config:
     proxy-body-size: 64m
     proxy-buffer-size: 16k
-  metrics:
-    enabled: true
 
 defaultBackend:
   enabled: false

--- a/kubernetes/kubecf/config/kubecf/values.yml
+++ b/kubernetes/kubecf/config/kubecf/values.yml
@@ -7,6 +7,8 @@ features:
     enabled: true
     annotations:
       kubernetes.io/ingress.class: nginx
+  suse_buildpacks:
+    enabled: false
 
 # https://github.com/cloudfoundry-incubator/kubecf/blob/84ac2c18bec4d62feb07875a387a7ad8108b82f4/deploy/helm/kubecf/values.yaml#L368-L386
 eirini:

--- a/kubernetes/kubecf/config/kubecf/values.yml
+++ b/kubernetes/kubecf/config/kubecf/values.yml
@@ -7,21 +7,6 @@ features:
     enabled: true
     annotations:
       kubernetes.io/ingress.class: nginx
-  suse_buildpacks:
-    enabled: false
-
-# https://github.com/cloudfoundry-incubator/kubecf/commit/91e54d7cca320755ddc07a2ac9d5db1b3a21ccc7
-# credentials:
-#   cf_admin_password: changeme
-#   credhub_tls.ca: credhub-real-ca
-#   credhub_tls.certificate: the-cert
-#   credhub_tls.private_key: the-real-key
-#   credhub_ca:
-#     certificate: cert
-#     is_ca: "true"
-#     private_key: key
-
-# variables: {}
 
 # https://github.com/cloudfoundry-incubator/kubecf/blob/84ac2c18bec4d62feb07875a387a7ad8108b82f4/deploy/helm/kubecf/values.yaml#L368-L386
 eirini:

--- a/kubernetes/kubecf/config/kubecf/values.yml
+++ b/kubernetes/kubecf/config/kubecf/values.yml
@@ -10,6 +10,19 @@ features:
   suse_buildpacks:
     enabled: false
 
+# https://github.com/cloudfoundry-incubator/kubecf/commit/91e54d7cca320755ddc07a2ac9d5db1b3a21ccc7
+# credentials:
+#   cf_admin_password: changeme
+#   credhub_tls.ca: credhub-real-ca
+#   credhub_tls.certificate: the-cert
+#   credhub_tls.private_key: the-real-key
+#   credhub_ca:
+#     certificate: cert
+#     is_ca: "true"
+#     private_key: key
+
+# variables: {}
+
 # https://github.com/cloudfoundry-incubator/kubecf/blob/84ac2c18bec4d62feb07875a387a7ad8108b82f4/deploy/helm/kubecf/values.yaml#L368-L386
 eirini:
   services:

--- a/kubernetes/kubecf/helmfile.yaml
+++ b/kubernetes/kubecf/helmfile.yaml
@@ -28,7 +28,7 @@ releases:
     createNamespace: true
     chart: ingress-nginx/ingress-nginx
     installed: true
-    version: ~2.0.x
+    version: ~2.1.x
     wait: true
     values:
       - config/ingress-nginx/values.yml

--- a/kubernetes/kubecf/helmfile.yaml
+++ b/kubernetes/kubecf/helmfile.yaml
@@ -17,7 +17,7 @@ releases:
     namespace: cf-operator
     createNamespace: true
     chart: quarks/cf-operator
-    version: 4.4.4
+    version: 4.5.6
     installed: true
     wait: true
     values:

--- a/kubernetes/kubecf/helmfile.yaml
+++ b/kubernetes/kubecf/helmfile.yaml
@@ -35,7 +35,7 @@ releases:
 
   - name: kubecf
     namespace: kubecf
-    chart: https://github.com/cloudfoundry-incubator/kubecf/releases/download/v2.1.0/kubecf-v2.1.0.tgz
+    chart: https://github.com/cloudfoundry-incubator/kubecf/releases/download/v2.2.0/kubecf-v2.2.0.tgz
     installed: true
     needs:
       - cf-operator/cf-operator

--- a/kubernetes/kubecf/helmfile.yaml
+++ b/kubernetes/kubecf/helmfile.yaml
@@ -35,7 +35,7 @@ releases:
 
   - name: kubecf
     namespace: kubecf
-    chart: https://github.com/cloudfoundry-incubator/kubecf/releases/download/v2.2.0/kubecf-v2.2.0.tgz
+    chart: https://github.com/cloudfoundry-incubator/kubecf/releases/download/v2.1.0/kubecf-v2.1.0.tgz
     installed: true
     needs:
       - cf-operator/cf-operator


### PR DESCRIPTION
- EDIT nevermind, having some weird problems with kubecf 2.2.0, so going to leave it as 2.1.0 and see what happens?
- nginx-ingress 2.1.0
- cf-operator 4.5.6

- turn off nginx-ingress metrics but leave the config option there, ya know? just for visibility... ya know? you know.

neato