### PR TITLE
jaeger-operator

### DIFF
--- a/jaeger-operator/Taskfile.yml
+++ b/jaeger-operator/Taskfile.yml
@@ -1,0 +1,15 @@
+---
+version: "2"
+
+tasks:
+  default:
+    cmds:
+      - exit 1
+      - |
+        kubectl -n jaeger-operator get jaeger
+        kubectl -n jaeger-operator delete jaeger.jaegertracing.io/jaeger-operator-jaeger
+        kubectl -n jaeger-operator get pods -l app.kubernetes.io/instance=jaeger-operator-jaeger
+        kubectl -n jaeger-operator logs -f -l app.kubernetes.io/instance=jaeger-operator-jaeger
+      - |
+        kubectl -n jaeger-operator get pods -l app.kubernetes.io/name=jaeger-operator
+        kubectl -n jaeger-operator logs -f -l app.kubernetes.io/name=jaeger-operator

--- a/jaeger-operator/config/ingress-nginx/values.yml
+++ b/jaeger-operator/config/ingress-nginx/values.yml
@@ -1,0 +1,15 @@
+---
+controller:
+  replicaCount: 1
+  hostNetwork: true
+  dnsPolicy: ClusterFirstWithHostNet
+  service:
+    type: NodePort
+  config:
+    proxy-body-size: 64m
+    proxy-buffer-size: 16k
+  metrics:
+    enabled: false
+
+defaultBackend:
+  enabled: false

--- a/jaeger-operator/config/jaeger-operator/values.yml
+++ b/jaeger-operator/config/jaeger-operator/values.yml
@@ -1,0 +1,13 @@
+# https://github.com/jaegertracing/jaeger-operator/blob/master/deploy/examples/all-in-one-with-options.yaml
+---
+jaeger:
+  create: true
+  spec:
+    strategy: allInOne
+    allInOne:
+      options:
+        log-level: debug
+    ingress:
+      enabled: true
+      hosts:
+        - jaeger.vcap.me

--- a/jaeger-operator/helmfile.yaml
+++ b/jaeger-operator/helmfile.yaml
@@ -1,0 +1,31 @@
+---
+helmDefaults:
+  kubeContext: kind-kind
+  wait: true
+
+repositories:
+  - name: ingress-nginx
+    url: https://kubernetes.github.io/ingress-nginx
+  - name: jaegertracing
+    url: https://jaegertracing.github.io/helm-charts
+
+releases:
+  - name: ingress-nginx
+    namespace: ingress-nginx
+    createNamespace: true
+    chart: ingress-nginx/ingress-nginx
+    installed: true
+    version: ~2.4.x
+    values:
+      - config/ingress-nginx/values.yml
+
+  - name: jaeger-operator
+    namespace: jaeger-operator
+    createNamespace: true
+    chart: jaegertracing/jaeger-operator
+    installed: true
+    version: ~2.15.x
+    needs:
+      - ingress-nginx/ingress-nginx
+    values:
+      - config/jaeger-operator/values.yml


### PR DESCRIPTION
see:
- https://www.jaegertracing.io/docs/1.18/troubleshooting/
- https://github.com/jaegertracing/jaeger-operator
- https://docs.openshift.com/container-platform/4.1/service_mesh/service_mesh_day_two/configuring-jaeger.html

role permissions on ingress currently failing against k8s 1.18.x, but should be squared away with https://github.com/jaegertracing/helm-charts/issues/112