### PR TITLE
prometheus-operator and nginx-ingress bumps

### DIFF
--- a/prometheus-operator/helmfile.yaml
+++ b/prometheus-operator/helmfile.yaml
@@ -15,7 +15,7 @@ releases:
     createNamespace: true
     chart: ingress-nginx/ingress-nginx
     installed: true
-    version: ~2.4.x
+    version: ~2.7.x
     values:
       - config/ingress-nginx/values.yml
 
@@ -24,7 +24,7 @@ releases:
     createNamespace: true
     chart: stable/prometheus-operator
     installed: true
-    version: ~8.14.x
+    version: ~8.15.x
     needs:
       - ingress-nginx/ingress-nginx
     values:


### PR DESCRIPTION
this doesn't include the latest changes of 0.40.0 (https://github.com/coreos/prometheus-operator/releases/tag/v0.40.0) in https://github.com/aegershman/deployments/issues/88, but it does bump stable chart here https://github.com/helm/charts/blob/master/stable/prometheus-operator/Chart.yaml