### PR TITLE
Concourse updates and concourse metrics

### DIFF
--- a/concourse/Taskfile.yml
+++ b/concourse/Taskfile.yml
@@ -4,7 +4,7 @@ version: "2"
 tasks:
   login:
     cmds:
-      - fly -t localhost login -c http://concourse.127.0.0.1.xip.io -u test -p test -n main -k
+      - fly -t localhost login -c http://concourse.vcap.me -u test -p test -n main -k
       - fly -t localhost sync
 
   set:

--- a/concourse/config/ingress-nginx/values.yml
+++ b/concourse/config/ingress-nginx/values.yml
@@ -5,29 +5,34 @@ controller:
   dnsPolicy: ClusterFirstWithHostNet
   service:
     type: NodePort
-
   # https://github.com/kubernetes/ingress-nginx/blob/6048e63daa2bd074a843f3caf344b1816bd703bc/charts/ingress-nginx/values.yaml#L429
   metrics:
     enabled: true
-  serviceMonitor:
-    enabled: true
-  prometheusRule:
-    enabled: true
-    rules:
-      # These are just examples rules, please adapt them to your needs
-      - alert: TooMany500s
-        expr: 100 * ( sum( nginx_ingress_controller_requests{status=~"5.+"} ) / sum(nginx_ingress_controller_requests) ) > 5
-        for: 1m
-        labels:
-          severity: critical
-        annotations:
-          description: Too many 5XXs
-          summary: More than 5% of the all requests did return 5XX, this require your attention
-      - alert: TooMany400s
-        expr: 100 * ( sum( nginx_ingress_controller_requests{status=~"4.+"} ) / sum(nginx_ingress_controller_requests) ) > 5
-        for: 1m
-        labels:
-          severity: critical
-        annotations:
-          description: Too many 4XXs
-          summary: More than 5% of the all requests did return 4XX, this require your attention
+    service:
+      type: NodePort
+    serviceMonitor:
+      enabled: true
+    prometheusRule:
+      enabled: true
+      rules:
+        # These are just examples rules, please adapt them to your needs
+        - alert: TooMany500s
+          expr: 100 * ( sum( nginx_ingress_controller_requests{status=~"5.+"} ) / sum(nginx_ingress_controller_requests) ) > 5
+          for: 1m
+          labels:
+            severity: critical
+          annotations:
+            description: Too many 5XXs
+            summary: More than 5% of the all requests did return 5XX, this require your attention
+        - alert: TooMany400s
+          expr: 100 * ( sum( nginx_ingress_controller_requests{status=~"4.+"} ) / sum(nginx_ingress_controller_requests) ) > 5
+          for: 1m
+          labels:
+            severity: critical
+          annotations:
+            description: Too many 4XXs
+            summary: More than 5% of the all requests did return 4XX, this require your attention
+  terminationGracePeriodSeconds: 10
+
+defaultBackend:
+  enabled: false

--- a/concourse/config/ingress-nginx/values.yml
+++ b/concourse/config/ingress-nginx/values.yml
@@ -5,5 +5,29 @@ controller:
   dnsPolicy: ClusterFirstWithHostNet
   service:
     type: NodePort
+
+  # https://github.com/kubernetes/ingress-nginx/blob/6048e63daa2bd074a843f3caf344b1816bd703bc/charts/ingress-nginx/values.yaml#L429
   metrics:
-    enabled: false
+    enabled: true
+  serviceMonitor:
+    enabled: true
+  prometheusRule:
+    enabled: true
+    rules:
+      # These are just examples rules, please adapt them to your needs
+      - alert: TooMany500s
+        expr: 100 * ( sum( nginx_ingress_controller_requests{status=~"5.+"} ) / sum(nginx_ingress_controller_requests) ) > 5
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          description: Too many 5XXs
+          summary: More than 5% of the all requests did return 5XX, this require your attention
+      - alert: TooMany400s
+        expr: 100 * ( sum( nginx_ingress_controller_requests{status=~"4.+"} ) / sum(nginx_ingress_controller_requests) ) > 5
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          description: Too many 4XXs
+          summary: More than 5% of the all requests did return 4XX, this require your attention

--- a/concourse/config/ingress-nginx/values.yml
+++ b/concourse/config/ingress-nginx/values.yml
@@ -9,7 +9,7 @@ controller:
   metrics:
     enabled: true
     service:
-      type: NodePort
+      type: ClusterIP
     serviceMonitor:
       enabled: true
     prometheusRule:
@@ -32,6 +32,12 @@ controller:
           annotations:
             description: Too many 4XXs
             summary: More than 5% of the all requests did return 4XX, this require your attention
+  # https://github.com/kubernetes/minikube/pull/5519/files
+  updateStrategy:
+    rollingUpdate:
+      # maxUnavailable needs to be 1 so that port conflicts between the old and new pod doesn't happen when using hostPort
+      maxUnavailable: 1
+      maxSurge: 1
   terminationGracePeriodSeconds: 10
 
 defaultBackend:

--- a/concourse/config/prometheus-operator/values.yml
+++ b/concourse/config/prometheus-operator/values.yml
@@ -1,7 +1,10 @@
+# https://github.com/helm/charts/blob/master/stable/prometheus-operator/values.yaml#L542
 ---
 alertmanager:
   ingress:
     enabled: true
+    annotations:
+      kubernetes.io/ingress.class: nginx
     hosts:
       - alertmanager.vcap.me
 
@@ -9,9 +12,10 @@ grafana:
   adminPassword: prom-operator
   ingress:
     enabled: true
+    annotations:
+      kubernetes.io/ingress.class: nginx
     hosts:
       - grafana.vcap.me
-  # https://github.com/helm/charts/blob/master/stable/prometheus-operator/values.yaml#L542
   additionalDataSources: []
 
 prometheusOperator:
@@ -20,5 +24,7 @@ prometheusOperator:
 prometheus:
   ingress:
     enabled: true
+    annotations:
+      kubernetes.io/ingress.class: nginx
     hosts:
       - prometheus.vcap.me

--- a/concourse/config/prometheus-operator/values.yml
+++ b/concourse/config/prometheus-operator/values.yml
@@ -1,0 +1,24 @@
+---
+alertmanager:
+  ingress:
+    enabled: true
+    hosts:
+      - alertmanager.vcap.me
+
+grafana:
+  adminPassword: prom-operator
+  ingress:
+    enabled: true
+    hosts:
+      - grafana.vcap.me
+  # https://github.com/helm/charts/blob/master/stable/prometheus-operator/values.yaml#L542
+  additionalDataSources: []
+
+prometheusOperator:
+  enabled: true
+
+prometheus:
+  ingress:
+    enabled: true
+    hosts:
+      - prometheus.vcap.me

--- a/concourse/config/prometheus-operator/values.yml
+++ b/concourse/config/prometheus-operator/values.yml
@@ -1,4 +1,3 @@
-# https://github.com/helm/charts/blob/master/stable/prometheus-operator/values.yaml#L542
 ---
 alertmanager:
   ingress:
@@ -16,6 +15,7 @@ grafana:
       kubernetes.io/ingress.class: nginx
     hosts:
       - grafana.vcap.me
+  # https://github.com/helm/charts/blob/master/stable/prometheus-operator/values.yaml#L542
   additionalDataSources: []
 
 prometheusOperator:
@@ -28,3 +28,7 @@ prometheus:
       kubernetes.io/ingress.class: nginx
     hosts:
       - prometheus.vcap.me
+
+  # https://github.com/helm/charts/issues/11310
+  prometheusSpec:
+    serviceMonitorSelectorNilUsesHelmValues: false

--- a/concourse/config/web/values.yml
+++ b/concourse/config/web/values.yml
@@ -12,11 +12,11 @@ web:
     annotations:
       kubernetes.io/ingress.class: nginx
     hosts:
-      - concourse.127.0.0.1.xip.io
+      - concourse.vcap.me
 
 concourse:
   web:
     clusterName: localhost
-    externalUrl: http://concourse.127.0.0.1.xip.io
+    externalUrl: http://concourse.vcap.me
     kubernetes:
       enabled: false

--- a/concourse/config/web/values.yml
+++ b/concourse/config/web/values.yml
@@ -20,3 +20,12 @@ concourse:
     externalUrl: http://concourse.vcap.me
     kubernetes:
       enabled: false
+
+    prometheus:
+      enabled: true
+      ## If Prometheus operator is used, also create a servicemonitor object
+      serviceMonitor:
+        enabled: true
+        interval: "30s"
+        # Namespace the servicemonitor object should be in
+        namespace:

--- a/concourse/config/workers/values.yml
+++ b/concourse/config/workers/values.yml
@@ -20,4 +20,4 @@ concourse:
     ephemeral: true
     tsa:
       hosts:
-        - web-web.concourse-web.svc.cluster.local:2222
+        - web-web-worker-gateway.concourse-web.svc.cluster.local:2222

--- a/concourse/helmfile.yaml
+++ b/concourse/helmfile.yaml
@@ -15,6 +15,7 @@ releases:
   - name: ingress-nginx
     namespace: ingress-nginx
     chart: ingress-nginx/ingress-nginx
+    installed: true
     version: ~2.7.x
     values:
       - config/ingress-nginx/values.yml
@@ -32,6 +33,7 @@ releases:
   - name: web
     namespace: concourse-web
     chart: concourse/concourse
+    installed: true
     version: ~11.2.x
     values:
       - config/web/values.yml
@@ -39,6 +41,7 @@ releases:
   - name: workers
     namespace: concourse-workers
     chart: concourse/concourse
+    installed: true
     version: ~11.2.x
     values:
       - config/workers/values.yml

--- a/concourse/helmfile.yaml
+++ b/concourse/helmfile.yaml
@@ -19,6 +19,16 @@ releases:
     values:
       - config/ingress-nginx/values.yml
 
+  - name: prometheus-operator
+    namespace: prometheus-operator
+    chart: stable/prometheus-operator
+    installed: true
+    version: ~8.15.x
+    needs:
+      - ingress-nginx/ingress-nginx
+    values:
+      - config/prometheus-operator/values.yml
+
   - name: web
     namespace: concourse-web
     chart: concourse/concourse
@@ -32,13 +42,3 @@ releases:
     version: ~11.2.x
     values:
       - config/workers/values.yml
-
-  - name: prometheus-operator
-    namespace: prometheus-operator
-    chart: stable/prometheus-operator
-    installed: true
-    version: ~8.15.x
-    needs:
-      - ingress-nginx/ingress-nginx
-    values:
-      - config/prometheus-operator/values.yml

--- a/concourse/helmfile.yaml
+++ b/concourse/helmfile.yaml
@@ -15,7 +15,7 @@ releases:
   - name: ingress-nginx
     namespace: ingress-nginx
     chart: ingress-nginx/ingress-nginx
-    version: ~2.4.x
+    version: ~2.7.x
     values:
       - config/ingress-nginx/values.yml
 

--- a/concourse/helmfile.yaml
+++ b/concourse/helmfile.yaml
@@ -22,14 +22,14 @@ releases:
   - name: web
     namespace: concourse-web
     chart: concourse/concourse
-    version: ~11.x.x
+    version: ~11.2.x
     values:
       - config/web/values.yml
 
   - name: workers
     namespace: concourse-workers
     chart: concourse/concourse
-    version: ~11.x.x
+    version: ~11.2.x
     values:
       - config/workers/values.yml
 

--- a/concourse/helmfile.yaml
+++ b/concourse/helmfile.yaml
@@ -32,3 +32,14 @@ releases:
     version: ~11.x.x
     values:
       - config/workers/values.yml
+
+  - name: prometheus-operator
+    namespace: prometheus-operator
+    createNamespace: true
+    chart: stable/prometheus-operator
+    installed: true
+    version: ~8.15.x
+    needs:
+      - ingress-nginx/ingress-nginx
+    values:
+      - config/prometheus-operator/values.yml

--- a/concourse/helmfile.yaml
+++ b/concourse/helmfile.yaml
@@ -35,7 +35,6 @@ releases:
 
   - name: prometheus-operator
     namespace: prometheus-operator
-    createNamespace: true
     chart: stable/prometheus-operator
     installed: true
     version: ~8.15.x

--- a/concourse/helmfile.yaml
+++ b/concourse/helmfile.yaml
@@ -16,6 +16,7 @@ releases:
     namespace: ingress-nginx
     chart: ingress-nginx/ingress-nginx
     installed: true
+    recreatePods: false
     version: ~2.7.x
     values:
       - config/ingress-nginx/values.yml


### PR DESCRIPTION
- add prometheus-operator to concourse
- have concourse and nginx-ingress emit metrics
- have concourse and nginx-ingress leverage service monitors
- update nginx-ingress so it doesn't do a rolling update, it just updates, because of the port allocation requirements when running on kind
- pin the version of concourse chart to the minor version
- mess around a little with the prometheus rules config
- swap to using vcap.me instead of xip.io, just to show some support to vcap.me, you know?
- update to leverage concourse worker gateway