### PR TITLE
prometheus labeling namespace matching

### DIFF
--- a/foundations/docker/localhost/kind/cf-for-k8s-demo/deployments/cf-for-k8s/_rendered/cf/cf-for-k8s-rendered.yml
+++ b/foundations/docker/localhost/kind/cf-for-k8s-demo/deployments/cf-for-k8s/_rendered/cf/cf-for-k8s-rendered.yml
@@ -1196,7 +1196,7 @@ spec:
           app.kubernetes.io/component: adapter
     - namespaceSelector:
         matchLabels:
-          name: prometheus-operator
+          cf-system-networking: friendly
   podSelector: {}
   policyTypes:
   - Ingress
@@ -1597,7 +1597,7 @@ spec:
           istio: ingressgateway
     - namespaceSelector:
         matchLabels:
-          name: prometheus-operator
+          cf-system-networking: friendly
 ---
 apiVersion: v1
 kind: Secret
@@ -14636,6 +14636,7 @@ kind: Namespace
 metadata:
   name: prometheus-operator
   labels:
+    cf-system-networking: friendly
     istio-injection: enabled
 ---
 apiVersion: networking.istio.io/v1alpha3

--- a/foundations/docker/localhost/kind/cf-for-k8s-demo/deployments/cf-for-k8s/_rendered/cf/cf-for-k8s-rendered.yml
+++ b/foundations/docker/localhost/kind/cf-for-k8s-demo/deployments/cf-for-k8s/_rendered/cf/cf-for-k8s-rendered.yml
@@ -1196,7 +1196,7 @@ spec:
           app.kubernetes.io/component: adapter
     - namespaceSelector:
         matchLabels:
-          cf-system-networking: friendly
+          cf-for-k8s.cloudfoundry.org/cf-system-ns: ""
   podSelector: {}
   policyTypes:
   - Ingress
@@ -1597,7 +1597,7 @@ spec:
           istio: ingressgateway
     - namespaceSelector:
         matchLabels:
-          cf-system-networking: friendly
+          cf-for-k8s.cloudfoundry.org/cf-system-ns: ""
 ---
 apiVersion: v1
 kind: Secret
@@ -13765,6 +13765,7 @@ metadata:
   name: cf-system
   labels:
     istio-injection: enabled
+    cf-for-k8s.cloudfoundry.org/cf-system-ns: ""
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -14636,7 +14637,7 @@ kind: Namespace
 metadata:
   name: prometheus-operator
   labels:
-    cf-system-networking: friendly
+    cf-for-k8s.cloudfoundry.org/cf-system-ns: ""
     istio-injection: enabled
 ---
 apiVersion: networking.istio.io/v1alpha3

--- a/foundations/docker/localhost/kind/cf-for-k8s-demo/deployments/cf-for-k8s/_rendered/cf/cf-for-k8s-rendered.yml
+++ b/foundations/docker/localhost/kind/cf-for-k8s-demo/deployments/cf-for-k8s/_rendered/cf/cf-for-k8s-rendered.yml
@@ -13766,6 +13766,7 @@ metadata:
   labels:
     istio-injection: enabled
     cf-for-k8s.cloudfoundry.org/cf-system-ns: ""
+    name: cf-system
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/foundations/docker/localhost/kind/cf-for-k8s-demo/deployments/cf-for-k8s/build/build.sh
+++ b/foundations/docker/localhost/kind/cf-for-k8s-demo/deployments/cf-for-k8s/build/build.sh
@@ -25,6 +25,7 @@ render)
     -f _vendir/github.com/cloudfoundry/cf-for-k8s/config-optional/patch-metrics-server.yml \
     -f ../_rendered/cf/cf-values-generated.yml \
     -f ../config/user/opsfiles/cf-registry-values.yml \
+    -f ../config/user/opsfiles/label-cf-system-namespace.yml \
     -f ../../harbor/user/opsfiles/harbor-namespace.yml \
     -f ../../harbor/user/opsfiles/harbor-virtual-service.yml \
     -f ../../jaeger-operator/user/opsfiles/jaeger-operator-namespace.yml \

--- a/foundations/docker/localhost/kind/cf-for-k8s-demo/deployments/cf-for-k8s/config/user/opsfiles/label-cf-system-namespace.yml
+++ b/foundations/docker/localhost/kind/cf-for-k8s-demo/deployments/cf-for-k8s/config/user/opsfiles/label-cf-system-namespace.yml
@@ -1,0 +1,8 @@
+#@ load("@ytt:overlay", "overlay")
+
+#@overlay/match by=overlay.and_op(overlay.subset({"metadata":{"name":"cf-system"}}), overlay.subset({"kind": "Namespace"}))
+---
+metadata:
+  labels:
+    #@overlay/match missing_ok=True
+    cf-for-k8s.cloudfoundry.org/cf-system-ns: ""

--- a/foundations/docker/localhost/kind/cf-for-k8s-demo/deployments/cf-for-k8s/config/user/opsfiles/label-cf-system-namespace.yml
+++ b/foundations/docker/localhost/kind/cf-for-k8s-demo/deployments/cf-for-k8s/config/user/opsfiles/label-cf-system-namespace.yml
@@ -6,3 +6,5 @@ metadata:
   labels:
     #@overlay/match missing_ok=True
     cf-for-k8s.cloudfoundry.org/cf-system-ns: ""
+    #@overlay/match missing_ok=True
+    name: "cf-system"

--- a/foundations/docker/localhost/kind/cf-for-k8s-demo/deployments/prometheus-operator/user/opsfiles/prometheus-network-policy.yml
+++ b/foundations/docker/localhost/kind/cf-for-k8s-demo/deployments/prometheus-operator/user/opsfiles/prometheus-network-policy.yml
@@ -11,4 +11,4 @@ spec:
         #@overlay/append
         - namespaceSelector:
             matchLabels:
-              name: prometheus-operator
+              cf-system-networking: friendly

--- a/foundations/docker/localhost/kind/cf-for-k8s-demo/deployments/prometheus-operator/user/opsfiles/prometheus-network-policy.yml
+++ b/foundations/docker/localhost/kind/cf-for-k8s-demo/deployments/prometheus-operator/user/opsfiles/prometheus-network-policy.yml
@@ -11,4 +11,4 @@ spec:
         #@overlay/append
         - namespaceSelector:
             matchLabels:
-              cf-system-networking: friendly
+              cf-for-k8s.cloudfoundry.org/cf-system-ns: ""

--- a/foundations/docker/localhost/kind/cf-for-k8s-demo/deployments/prometheus-operator/user/opsfiles/prometheus-operator-namespace.yml
+++ b/foundations/docker/localhost/kind/cf-for-k8s-demo/deployments/prometheus-operator/user/opsfiles/prometheus-operator-namespace.yml
@@ -4,7 +4,7 @@ kind: Namespace
 metadata:
   name: prometheus-operator
   labels:
-    cf-system-networking: friendly
+    cf-for-k8s.cloudfoundry.org/cf-system-ns: ""
 
 #@ load("@ytt:overlay", "overlay")
 #@overlay/match by=overlay.and_op(overlay.subset({"metadata":{"name":"prometheus-operator"}}), overlay.subset({"kind": "Namespace"}))

--- a/foundations/docker/localhost/kind/cf-for-k8s-demo/deployments/prometheus-operator/user/opsfiles/prometheus-operator-namespace.yml
+++ b/foundations/docker/localhost/kind/cf-for-k8s-demo/deployments/prometheus-operator/user/opsfiles/prometheus-operator-namespace.yml
@@ -3,6 +3,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: prometheus-operator
+  labels:
+    cf-system-networking: friendly
 
 #@ load("@ytt:overlay", "overlay")
 #@overlay/match by=overlay.and_op(overlay.subset({"metadata":{"name":"prometheus-operator"}}), overlay.subset({"kind": "Namespace"}))

--- a/foundations/docker/localhost/kind/cf-for-k8s-demo/helmfile.yaml
+++ b/foundations/docker/localhost/kind/cf-for-k8s-demo/helmfile.yaml
@@ -49,7 +49,7 @@ releases:
     installed: true
     version: ~8.15.x
     values:
-      - ./deployments/prometheus-operator/user/helm/values.yml
+      - ./deployments/prometheus-operator/build/values.yml
 
   - name: service-catalog
     namespace: catalog


### PR DESCRIPTION
In order to have the `networkpolicy` associate to the namespace prometheus is hanging out in, `matchLabel` namespace configuration needs to be updated to actually match on a namespace label, not the namespace itself.
