### PR TITLE
return harbor cert to harbor ns

### DIFF
--- a/foundations/aws/us-east-2/sandbox/cf-for-k8s-demo/deploy-ctl.sh
+++ b/foundations/aws/us-east-2/sandbox/cf-for-k8s-demo/deploy-ctl.sh
@@ -105,13 +105,12 @@ a | apply | deploy)
     ;;
   h | harbor)
     shift
-    # -f ./cluster/config-optional/harbor/harbor-cert-manager-staging.yml \
     kapp deploy -a harbor -f <(
       ytt \
         -f ./cluster/config/harbor/ \
+        -f ./cluster/config-optional/harbor/harbor-cert-manager-prod.yml \
         -f ./cluster/config-optional/harbor/label-ns-quarks-secret-monitor.yml
     ) "$@"
-    # -f ./cluster/config-optional/harbor/harbor-cert-manager-prod.yml \
     ;;
   qs | quarks-secret)
     shift


### PR DESCRIPTION
in the future, this should be scooted over to having this certificate be centralized then shared across namespaces likely using secretgen-controller as per https://github.com/k14s/secretgen-controller/issues/2

closes https://github.com/aegershman/deployments/issues/156